### PR TITLE
ENH: add "native" way to invoke pynwb tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,11 @@ requirements:
 test:
   imports:
     - pynwb
+  source_files:
+    - test.py
+    - tests
   commands:
-    - ./test.py --pynwb
+    - python ./test.py --pynwb
 
 about:
   home: https://github.com/NeurodataWithoutBorders/pynwb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,6 +33,8 @@ requirements:
 test:
   imports:
     - pynwb
+  commands:
+    - ./test.py --pynwb
 
 about:
   home: https://github.com/NeurodataWithoutBorders/pynwb


### PR DESCRIPTION
Up until now I believe package building does not include running the
tests, thus there is no assurance that conda package is functioning correctly

TODO: 
- [ ] make it build for every OS separately, so tests run not only on linux one version
- [ ] after figuring it out here, introduce to hdmf-feedstock as well